### PR TITLE
Support for integers as array values

### DIFF
--- a/lib/action_view/helpers/hash_to_hidden_fields.rb
+++ b/lib/action_view/helpers/hash_to_hidden_fields.rb
@@ -6,7 +6,8 @@ module ActionView
   module Helpers
     module HashToHiddenFields
       def hash_to_hidden_fields(hash)
-        pairs        = hash.to_query.split(Rack::Utils::DEFAULT_SEP)
+        cleaned_hash = hash.reject { |k, v| v.nil? }
+        pairs        = cleaned_hash.to_query.split(Rack::Utils::DEFAULT_SEP)
 
         tags = pairs.map do |pair|
           key, value = pair.split('=', 2).map { |str| Rack::Utils.unescape(str) }

--- a/spec/hash_to_hidden_fields_spec.rb
+++ b/spec/hash_to_hidden_fields_spec.rb
@@ -8,6 +8,7 @@ test_hash = {
     "nested1" => "3",
     "nested2" => "4"
   },
+  "nil" => nil,
   "array" => [
     1, 2, "3", "abc"
   ],


### PR DESCRIPTION
I was having an issue where a hash like the following:

``` ruby
{ some_key: [1, 2, 3] }
```

Was producing code with empty values:

```
<input name="some_key[]" value="" />
```

Finally tracked it down to Rack::Utils.build_nested_query not supporting integers.  This commit adds a test for the integer behavior and switches to using ActiveSupports' #to_query which is what url_for uses for building up the query string.
